### PR TITLE
fix: 프롬프트 이미지 예외처리 추가

### DIFF
--- a/app/prompts/generate_prompt.py
+++ b/app/prompts/generate_prompt.py
@@ -44,11 +44,12 @@ return_fields=["objects","attributes","text","confidence"]
     - 내용(content): 이미지에서 읽을 수 있는 텍스트 제외 한국어(존댓말), 100자 이내. 
     - 절대 과장하거나 사실과 다른 정보를 기입하지 마세요.
     - 이미지에 없는 정보는 절대 만들어내지 마세요.(예: 이미지에 상자가 없는데 '상자 포함'으로 작성) 
-    - 확실하지 않은 정보는 추정하지 마세요.
+    - 확실하지 않은 정보(원가, 구매년도)는 작성하지 마세요.
     - 문자열 길이가 제한을 초과하지 않도록 작성하세요.
 4. 예외 및 추가 규칙
     - 이미지가 손상 상태로 보이거나 안전 문제 소지가 있으면 게시물 작성을 거부하세요.
-    - 판매 불가한 물품이면 게시글 작성을 거부하세요.     
+    - 이미지의 물건이 위험하거나 법적으로 판매가 불가능하면 게시글 작성을 거부하세요.     
+    - 이미지가 자연환경(예: 산, 바다, 하늘), 장소(예: 거실 사진, 카페 사진)과 같이 물건이 아닌 장소 사진이라면 게시글 작성을 거부하세요.
     - 항상 최대한 정중하고 간결한 한국어 존댓말을 사용하세요.
     - Remember: Do not add extra sections beyond the specified JSON structure unless requesting clarification (questions array).
 
@@ -60,11 +61,11 @@ return_fields=["objects","attributes","text","confidence"]
         "content": "<100자 이내 상세하고 정성스레 작성한 내용>"
         }
         
-    - 만약 이미지가 불충분하거나 판매 불가한 물품이거나 예외로 인해 게시글 작성을 거부하는 경우 다음 형식으로 반환하세요:
+    - 만약 이미지가 불충분하거나 예외로 인해 게시글 작성을 거부하는 경우 다음 형식으로 반환하세요:
         
         {
-        "title": null,
-        "content": null
+        "title": "대여글 생성이 불가능한 이미지입니다.",
+        "content": "대여글 생성이 불가능한 이미지입니다."
         }
         
 Remember to follow these instructions precisely. 
@@ -92,7 +93,7 @@ Example 1 — 단일 물건(명확)
 
 </final_response>
 
-Example 2 — 물건 종류는 1개인데 개수가 여러 개(예시에서는 3개)
+Example 2 — 명확한 브랜드가 확인이 가능한 물건, 개수가 여러 개(예시에서는 스노우피크 브랜드, 개수: 3개)
 
 <final_response>
 
@@ -103,13 +104,34 @@ Example 2 — 물건 종류는 1개인데 개수가 여러 개(예시에서는 3
 
 </final_response>
 
-Example 3 — 여러 다른 물건이 섞여 있거나 판매 불가능한 물건이면 제목, 내용 null 반환
+Example 3 — 여러 다른 물건이 섞여 있거나 판매 불가능한 물건
 
 <final_response>
 
 {
-"title": null,
-"content": null
+"title": "대여가 불가능한 물건입니다.",
+"content": "대여가 불가능한 물건입니다."
+}
+</final_response>
+
+Example 4 — 위험하거나 법적으로 판매 불가능한 물건
+
+<final_response>
+
+{
+"title": "대여가 불가능한 물건입니다.",
+"content": "대여가 불가능한 물건입니다."
+}
+
+</final_response>
+
+Example 4 — 이미지가 자연환경이나 장소 등 물건이 아닌 경우
+
+<final_response>
+
+{
+"title": "대여글 생성이 불가능한 이미지입니다.",
+"content": "대여글 생성이 불가능한 이미지입니다."
 }
 
 </final_response>


### PR DESCRIPTION
## 내용
- 내용 생성 예외처리 null에서 안내 텍스트로 변경
## 테스트
- 예외처리 이미지 테스트 시 스키마와 타입 불일치 문제 해결
  - 해당 이슈는 ai 기능 테스트 시 간헐적인 500 에러의 원인으로 추정 