### PR TITLE
fix: vLLM  prefix caching 비활성화

### DIFF
--- a/serverless/Dockerfile
+++ b/serverless/Dockerfile
@@ -14,4 +14,5 @@ CMD python3 -m vllm.entrypoints.openai.api_server \
     --enforce-eager \
     --limit-mm-per-prompt '{"image":5}' \
     --gpu-memory-utilization 0.9 \
+    --enable-prefix-caching false \
     & python3 -u serverless/handler.py


### PR DESCRIPTION
## 내용
도커파일 수정
- 모델 응답 캐싱처리 의심되어 엔진 내 prefix caching 옵션 비활성화 명시