### PR TITLE
fix: 서버리스 도커파일 리팩토링, 롤백

### DIFF
--- a/serverless/Dockerfile.runpod
+++ b/serverless/Dockerfile.runpod
@@ -15,4 +15,4 @@ CMD python3 -m vllm.entrypoints.openai.api_server \
     --limit-mm-per-prompt '{"image":5}' \
     --gpu-memory-utilization 0.9 \
     --enable-prefix-caching false \
-    & python3 -u handler.py
+    & python3 -u serverless/handler.py


### PR DESCRIPTION
## 내용
- 서버리스쪽 도커파일 이름 리팩토링
  - serverless/Dockerfile -> serverless/Dockerfile.runpod

- 서버리스 도커파일 내 핸들러 경로 롤백