### PR TITLE
Fix/docker fix

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,6 @@ pydantic==2.12.5
 python-dotenv==1.2.1
 httpx==0.28.1
 Pillow==12.1.0
-runpod==1.8.1
 transformers==5.2.0
 torch==2.10.0
 boto3==1.42.36

--- a/serverless/Dockerfile.runpod
+++ b/serverless/Dockerfile.runpod
@@ -3,7 +3,7 @@ WORKDIR /
 
 COPY requirements.txt .
 RUN pip3 install --no-cache-dir -r requirements.txt
-RUN pip3 install --no-cache-dir runpod
+#RUN pip3 install --no-cache-dir runpod
 COPY . .
 
 # 핸들러 요청

--- a/serverless/requirements.txt
+++ b/serverless/requirements.txt
@@ -1,0 +1,3 @@
+python-dotenv==1.2.1
+httpx==0.28.1
+runpod==1.8.1


### PR DESCRIPTION
## 내용
- 루트와 서버리스의 requirements 분리
- 런팟에서 Build Context 경로를 serverless로 설정 (root의 Dockerfile과의 충돌 피하기 위해)
- Build Context 경로 변경에 따른 핸들러 경로 변경.

## 테스트
- fix/docker-fix 브랜치 방향을 가리키는 서버리스 모델과 로컬 테스트 완료.