### PR TITLE
fix: 시멘틱 서치 예외처리

### DIFF
--- a/app/services/qdrant_service.py
+++ b/app/services/qdrant_service.py
@@ -155,6 +155,8 @@ class QdrantService:
                         prices.append(int(hit.payload.get("price")))
                     except (ValueError, TypeError):
                         continue
+                else:
+                    print("유사 물건 없음.")
             return prices
         except Exception as e:
             print(f"Qdrant 서치 중 에러: {str(e)}")


### PR DESCRIPTION
## 내용
- 시세 산정 위한 시멘틱 서치 시 Qdrant와의 접속 이슈 시 에러 로그 반환으로 일어나는 시세 산정에서의 TypeError(ValueError) 예방