### PR TITLE
fix: vllm 다운그레이드에 의한 도커 수정

### DIFF
--- a/serverless/Dockerfile.runpod
+++ b/serverless/Dockerfile.runpod
@@ -12,7 +12,7 @@ CMD python3 -m vllm.entrypoints.openai.api_server \
     --model Qwen/Qwen2.5-VL-7B-Instruct \
     --max-model-len 4096 \
     --enforce-eager \
-    --limit-mm-per-prompt '{"image":5}' \
+    --limit-mm-per-prompt image=5 \
     --gpu-memory-utilization 0.9 \
-    --enable-prefix-caching false \
+    --no-enable-prefix-caching \
     & python3 -u handler.py


### PR DESCRIPTION
## 내용
(validate에 Llama-Guard-3-Vision-11B(Quantization) 도커파일 추가가 되면서 vllm이 다운그레이드 되었다.)
vllm 버전 다운그레이드에 따른 기존 Qwen 모델 도커파일 문법 수정
